### PR TITLE
Potential fix for code scanning alert no. 27: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -3,6 +3,9 @@
 
 name: Metriq API CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/unitaryfoundation/metriq-api/security/code-scanning/27](https://github.com/unitaryfoundation/metriq-api/security/code-scanning/27)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the least privileges required for the workflow to function. Since the workflow only checks out the repository and installs/builds dependencies, it only needs `contents: read` permission. This change ensures that the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
