### PR TITLE
Potential fix for code scanning alert no. 14: Database query built from user-controlled sources

### DIFF
--- a/metriq-api/service/taskService.js
+++ b/metriq-api/service/taskService.js
@@ -130,21 +130,22 @@ class TaskService extends ModelService {
   async getParentSubmissionCount (parentId) {
     return (await sequelize.query(
       'WITH RECURSIVE c AS ( ' +
-      '  SELECT ' + parentId + ' as id ' +
+      '  SELECT :parentId as id ' +
       '  UNION ALL ' +
       '  SELECT tasks.id as id FROM tasks ' +
       '    JOIN c on c.id = tasks."taskId" ' +
       ') ' +
       'SELECT COUNT(*) FROM "submissionTaskRefs" AS tr ' +
       '  RIGHT JOIN c on c.id = tr."taskId" ' +
-      '  WHERE tr."deletedAt" IS NULL AND tr.id IS NOT NULL '
+      '  WHERE tr."deletedAt" IS NULL AND tr.id IS NOT NULL ',
+      { replacements: { parentId } }
     ))[0][0].count
   }
 
   async getParentLikeCount (parentId) {
     return (await sequelize.query(
       'WITH RECURSIVE c AS ( ' +
-      '  SELECT ' + parentId + ' as id ' +
+      '  SELECT :parentId as id ' +
       '  UNION ALL ' +
       '  SELECT tasks.id as id FROM tasks ' +
       '    JOIN c on c.id = tasks."taskId" ' +
@@ -153,14 +154,15 @@ class TaskService extends ModelService {
       '  RIGHT JOIN submissions on likes."submissionId" = submissions.id ' +
       '  RIGHT JOIN "submissionTaskRefs" tr on submissions.id = tr."submissionId" ' +
       '  RIGHT JOIN c on c.id = tr."taskId" ' +
-      '  WHERE submissions."deletedAt" IS NULL AND tr."deletedAt" IS NULL AND tr.id IS NOT NULL '
+      '  WHERE submissions."deletedAt" IS NULL AND tr."deletedAt" IS NULL AND tr.id IS NOT NULL ',
+      { replacements: { parentId } }
     ))[0][0].count
   }
 
   async getParentResultCount (parentId) {
     return (await sequelize.query(
       'WITH RECURSIVE c AS ( ' +
-      '  SELECT ' + parentId + ' as id ' +
+      '  SELECT :parentId as id ' +
       '  UNION ALL ' +
       '  SELECT tasks.id as id FROM tasks ' +
       '    JOIN c on c.id = tasks."taskId" ' +
@@ -168,7 +170,8 @@ class TaskService extends ModelService {
       'SELECT COUNT(*) FROM results ' +
       '  RIGHT JOIN "submissionTaskRefs" tr on results."submissionTaskRefId" = tr.id ' +
       '  RIGHT JOIN c on c.id = tr."taskId" ' +
-      '  WHERE tr."deletedAt" IS NULL AND tr.id IS NOT NULL AND results."deletedAt" IS NULL '
+      '  WHERE tr."deletedAt" IS NULL AND tr.id IS NOT NULL AND results."deletedAt" IS NULL ',
+      { replacements: { parentId } }
     ))[0][0].count
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/unitaryfoundation/metriq-api/security/code-scanning/14](https://github.com/unitaryfoundation/metriq-api/security/code-scanning/14)

To fix the issue, we need to prevent SQL injection by using parameterized queries instead of directly concatenating user input into query strings. Sequelize's `sequelize.query` method supports parameterized queries, which allow us to safely embed user input into the query.

For each vulnerable method (`getParentSubmissionCount`, `getParentLikeCount`, `getParentResultCount`, etc.), we will replace the concatenated query strings with parameterized queries. The `parentId` will be passed as a parameter to ensure it is treated as a literal value.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
