### PR TITLE
Potential fix for code scanning alert no. 10: Database query built from user-controlled sources

### DIFF
--- a/metriq-api/service/submissionSqlService.js
+++ b/metriq-api/service/submissionSqlService.js
@@ -100,11 +100,11 @@ class SubmissionSqlService {
             '    WHERE s."deletedAt" IS NULL AND s."publishedAt" IS NOT NULL AND str."deletedAt" IS NULL AND str."dataSetId" = ' + dataSetId
   }
 
-  sqlByPlatform (platformId) {
+  sqlByPlatform () {
     return 'SELECT s.*, CAST(l."upvoteCount" AS integer) AS "upvoteCount" FROM submissions AS s ' +
             '    RIGHT JOIN public."submissionPlatformRefs" AS str ON s.id = str."submissionId" ' +
             '    LEFT JOIN (SELECT "submissionId", COUNT(*) as "upvoteCount" from likes GROUP BY "submissionId") as l on l."submissionId" = s.id ' +
-            '    WHERE s."deletedAt" IS NULL AND s."publishedAt" IS NOT NULL AND str."deletedAt" IS NULL AND str."platformId" = ' + platformId
+            '    WHERE s."deletedAt" IS NULL AND s."publishedAt" IS NOT NULL AND str."deletedAt" IS NULL AND str."platformId" = :platformId'
   }
 
   sqlSubmittedToday () {
@@ -124,7 +124,7 @@ class SubmissionSqlService {
   }
 
   async getByPlatformId (platformId) {
-    const result = (await sequelize.query(this.sqlByPlatform(platformId)))[0]
+    const result = (await sequelize.query(this.sqlByPlatform(), { replacements: { platformId }, type: sequelize.QueryTypes.SELECT }))[0]
     return { success: true, body: result }
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/unitaryfoundation/metriq-api/security/code-scanning/10](https://github.com/unitaryfoundation/metriq-api/security/code-scanning/10)

To fix the issue, we will replace the raw string concatenation in the `sqlByPlatform` method with a parameterized query. Sequelize's `sequelize.query` method supports parameterized queries, which safely embed user input into the query. This approach ensures that the `platformId` is treated as a literal value and not executable SQL code.

Steps to fix:
1. Modify the `sqlByPlatform` method to use a parameterized query with a placeholder for `platformId`.
2. Update the `getByPlatformId` method to pass the `platformId` as a parameter to the query.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
