### PR TITLE
Potential fix for code scanning alert no. 9: Database query built from user-controlled sources

### DIFF
--- a/metriq-api/service/submissionSqlService.js
+++ b/metriq-api/service/submissionSqlService.js
@@ -86,11 +86,11 @@ class SubmissionSqlService {
         '    WHERE s."deletedAt" IS NULL AND s."publishedAt" IS NOT NULL;'
   }
 
-  sqlByMethod (methodId) {
+  sqlByMethod () {
     return 'SELECT s.*, CAST(l."upvoteCount" AS integer) AS "upvoteCount" FROM submissions AS s ' +
             '    RIGHT JOIN public."submissionMethodRefs" AS str ON s.id = str."submissionId" ' +
             '    LEFT JOIN (SELECT "submissionId", COUNT(*) as "upvoteCount" from likes GROUP BY "submissionId") as l on l."submissionId" = s.id ' +
-            '    WHERE s."deletedAt" IS NULL AND s."publishedAt" IS NOT NULL AND str."deletedAt" IS NULL AND str."methodId" = ' + methodId
+            '    WHERE s."deletedAt" IS NULL AND s."publishedAt" IS NOT NULL AND str."deletedAt" IS NULL AND str."methodId" = :methodId'
   }
 
   sqlByDataSet (dataSetId) {
@@ -119,7 +119,7 @@ class SubmissionSqlService {
   }
 
   async getByMethodId (methodId) {
-    const result = (await sequelize.query(this.sqlByMethod(methodId)))[0]
+    const result = (await sequelize.query(this.sqlByMethod(), { replacements: { methodId }, type: sequelize.QueryTypes.SELECT }))[0]
     return { success: true, body: result }
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/unitaryfoundation/metriq-api/security/code-scanning/9](https://github.com/unitaryfoundation/metriq-api/security/code-scanning/9)

To fix the issue, we should use parameterized queries to safely embed the `methodId` into the SQL query. This approach prevents SQL injection by treating the user input as a literal value rather than executable SQL code. Sequelize supports parameterized queries through the use of replacements or bind parameters.

Specifically:
1. Modify the `sqlByMethod` function to use a parameterized query with a placeholder for `methodId`.
2. Pass the `methodId` as a parameter when calling `sequelize.query`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
