### PR TITLE
Potential fix for code scanning alert no. 8: Database query built from user-controlled sources

### DIFF
--- a/metriq-api/service/submissionSqlService.js
+++ b/metriq-api/service/submissionSqlService.js
@@ -69,9 +69,9 @@ class SubmissionSqlService {
             'LIMIT ' + limit + ' OFFSET ' + offset
   }
 
-  sqlByTask (taskId) {
+  sqlByTask () {
     return 'WITH RECURSIVE c AS ( ' +
-        '    SELECT ' + taskId + ' as id ' +
+        '    SELECT $1 as id ' +
         '    UNION ALL ' +
         '    SELECT t.id FROM tasks AS t ' +
         '    JOIN c on c.id = t."taskId" ' +
@@ -114,7 +114,7 @@ class SubmissionSqlService {
   }
 
   async getByTaskId (taskId) {
-    const result = (await sequelize.query(this.sqlByTask(taskId)))[0]
+    const result = (await sequelize.query(this.sqlByTask(), { replacements: [taskId], type: sequelize.QueryTypes.SELECT }))[0]
     return { success: true, body: result }
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/unitaryfoundation/metriq-api/security/code-scanning/8](https://github.com/unitaryfoundation/metriq-api/security/code-scanning/8)

To fix the issue, we should use parameterized queries to safely embed the `taskId` into the SQL query. Parameterized queries ensure that user input is treated as a literal value rather than executable SQL code, effectively preventing SQL injection attacks.

1. Modify the `sqlByTask` method in `submissionSqlService.js` to accept `taskId` as a parameter and use a placeholder (`$1`) in the query string.
2. Update the `getByTaskId` method to pass the `taskId` as a parameter to the `sequelize.query` method.
3. Ensure that similar changes are applied to other methods (`sqlByMethod`, `sqlByDataSet`, etc.) if they are also vulnerable.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
