### PR TITLE
Potential fix for code scanning alert no. 6: Database query built from user-controlled sources

### DIFF
--- a/metriq-api/service/platformService.js
+++ b/metriq-api/service/platformService.js
@@ -115,26 +115,29 @@ class PlatformService extends ModelService {
 
   async getTopLevelNamesByArchitecture (architectureId) {
     return (await sequelize.query(
-      'SELECT id, name, description, url FROM platforms WHERE platforms."platformId" is NULL AND platforms."isDataSet" = FALSE AND platforms."architectureId" = ' + architectureId
+      'SELECT id, name, description, url FROM platforms WHERE platforms."platformId" is NULL AND platforms."isDataSet" = FALSE AND platforms."architectureId" = $1',
+      { bind: [architectureId], type: sequelize.QueryTypes.SELECT }
     ))[0]
   }
 
   async getTopLevelNamesByProvider (providerId) {
     return (await sequelize.query(
-      'SELECT id, name, description, url FROM platforms WHERE platforms."platformId" is NULL AND platforms."isDataSet" = FALSE AND platforms."providerId" = ' + providerId
+      'SELECT id, name, description, url FROM platforms WHERE platforms."platformId" is NULL AND platforms."isDataSet" = FALSE AND platforms."providerId" = $1',
+      { bind: [providerId], type: sequelize.QueryTypes.SELECT }
     ))[0]
   }
 
   async getParentSubmissionCount (parentId) {
     return (await sequelize.query(
       'WITH RECURSIVE c AS ( ' +
-      '  SELECT ' + parentId + ' as id ' +
+      '  SELECT $1 as id ' +
       '  UNION ALL ' +
       '  SELECT platforms.id as id FROM platforms ' +
       '    JOIN c on c.id = platforms."platformId" ' +
       ') ' +
       'SELECT COUNT(*) FROM "submissionPlatformRefs" AS spr ' +
-      '  RIGHT JOIN c on c.id = spr."platformId" AND spr."deletedAt" IS NULL AND spr.id IS NOT NULL '
+      '  RIGHT JOIN c on c.id = spr."platformId" AND spr."deletedAt" IS NULL AND spr.id IS NOT NULL ',
+      { bind: [parentId], type: sequelize.QueryTypes.SELECT }
     ))[0][0].count
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/unitaryfoundation/metriq-api/security/code-scanning/6](https://github.com/unitaryfoundation/metriq-api/security/code-scanning/6)

To fix the issue, we need to use parameterized queries to safely embed user-controlled input into the SQL query. This approach ensures that the input is treated as a literal value rather than executable SQL code, effectively mitigating the risk of SQL injection.

1. Replace the string concatenation in the SQL queries with parameterized placeholders (e.g., `?` or `$1`).
2. Pass the user-controlled input as a separate parameter to the `sequelize.query` method.
3. Update the methods `getTopLevelNamesByArchitecture`, `getTopLevelNamesByProvider`, and `getParentSubmissionCount` in `platformService.js` to use parameterized queries.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
