### PR TITLE
Potential fix for code scanning alert no. 4: Database query built from user-controlled sources

### DIFF
--- a/metriq-api/service/providerService.js
+++ b/metriq-api/service/providerService.js
@@ -40,7 +40,10 @@ class ProviderService extends ModelService {
   }
 
   async getAllNamesByArchitecture (architectureId) {
-    const result = (await sequelize.query('SELECT DISTINCT providers.id, providers.name FROM providers RIGHT JOIN platforms on providers.id = platforms."providerId" WHERE platforms.id IS NOT NULL AND platforms."architectureId" = ' + architectureId))[0]
+    const result = (await sequelize.query(
+      'SELECT DISTINCT providers.id, providers.name FROM providers RIGHT JOIN platforms on providers.id = platforms."providerId" WHERE platforms.id IS NOT NULL AND platforms."architectureId" = :architectureId',
+      { replacements: { architectureId }, type: sequelize.QueryTypes.SELECT }
+    ));
     return { success: true, body: result }
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/unitaryfoundation/metriq-api/security/code-scanning/4](https://github.com/unitaryfoundation/metriq-api/security/code-scanning/4)

To fix the issue, the SQL query should use parameterized queries to safely embed the `architectureId` into the query. Parameterized queries ensure that user input is treated as a literal value rather than executable SQL code, thereby preventing SQL injection attacks.

In this case, the `sequelize.query` method supports parameterized queries by using placeholders (e.g., `:paramName`) and passing the parameters as a separate object. The `architectureId` should be passed as a parameter instead of being concatenated into the query string.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
