### PR TITLE
Potential fix for code scanning alert no. 3: Database query built from user-controlled sources

### DIFF
--- a/metriq-api/service/platformService.js
+++ b/metriq-api/service/platformService.js
@@ -35,7 +35,8 @@ class PlatformService extends ModelService {
     return (await sequelize.query(
       'SELECT COUNT(*) FROM "resultPlatformRefs" ' +
       '  RIGHT JOIN platforms on platforms.id = "resultPlatformRefs"."platformId" AND ("resultPlatformRefs"."deletedAt" IS NULL) ' +
-      '  WHERE platforms.id = ' + platformId
+      '  WHERE platforms.id = :platformId',
+      { replacements: { platformId } }
     ))[0][0].count
   }
 
@@ -46,7 +47,8 @@ class PlatformService extends ModelService {
       '  RIGHT JOIN results on results."submissionTaskRefId" = "submissionTaskRefs".id AND (results."deletedAt" IS NULL) ' +
       '  RIGHT JOIN "resultPlatformRefs" on "resultPlatformRefs"."resultId" = results.id AND ("resultPlatformRefs"."deletedAt" IS NULL) ' +
       '  RIGHT JOIN platforms on platforms.id = "resultPlatformRefs"."platformId" ' +
-      '  WHERE platforms.id = ' + platformId
+      '  WHERE platforms.id = :platformId',
+      { replacements: { platformId } }
     ))[0][0].count
   }
 
@@ -58,7 +60,8 @@ class PlatformService extends ModelService {
       '  RIGHT JOIN results on results."submissionTaskRefId" = "submissionTaskRefs".id AND (results."deletedAt" IS NULL) ' +
       '  RIGHT JOIN "resultPlatformRefs" on "resultPlatformRefs"."resultId" = results.id AND ("resultPlatformRefs"."deletedAt" IS NULL) ' +
       '  RIGHT JOIN platforms on platforms.id = "resultPlatformRefs"."platformId" ' +
-      '  WHERE platforms.id = ' + platformId
+      '  WHERE platforms.id = :platformId',
+      { replacements: { platformId } }
     ))[0][0].count
   }
 
@@ -68,7 +71,8 @@ class PlatformService extends ModelService {
       '  LEFT JOIN "platformDataTypeValues" on platforms.id = "platformDataTypeValues"."platformId" ' +
       '  LEFT JOIN "platformDataTypes" on "platformDataTypes".id = "platformDataTypeValues"."platformDataTypeId" ' +
       '  LEFT JOIN "dataTypes" on "platformDataTypes"."dataTypeId" = "dataTypes".id ' +
-      '  WHERE platforms.id = ' + platformId
+      '  WHERE platforms.id = :platformId',
+      { replacements: { platformId } }
     ))[0]
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/unitaryfoundation/metriq-api/security/code-scanning/3](https://github.com/unitaryfoundation/metriq-api/security/code-scanning/3)

To fix the issue, we need to use parameterized queries to safely embed the `platformId` into the SQL query. This approach ensures that the input is treated as a literal value rather than executable SQL code, preventing SQL injection attacks.

**Steps to fix:**
1. Replace the raw string concatenation in the SQL queries with parameterized queries using Sequelize's query parameter syntax (`?` or named parameters like `:platformId`).
2. Pass the `platformId` as a parameter to the query method.
3. Ensure that all methods (`getResultCount`, `getSubmissionCount`, `getLikeCount`, and `getPropertiesByPk`) are updated to use this approach.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
