### PR TITLE
Potential fix for code scanning alert no. 2: Database query built from user-controlled sources

### DIFF
--- a/metriq-api/service/methodService.js
+++ b/metriq-api/service/methodService.js
@@ -130,8 +130,9 @@ class MethodService extends ModelService {
 
   async getChildren (parentId) {
     return (await sequelize.query(
-      'SELECT * FROM methods WHERE methods."methodId" = ' + parentId + ';'
-    ))[0]
+      'SELECT * FROM methods WHERE methods."methodId" = :parentId;',
+      { replacements: { parentId }, type: sequelize.QueryTypes.SELECT }
+    ))
   }
 
   async getByName (name) {


### PR DESCRIPTION
Potential fix for [https://github.com/unitaryfoundation/metriq-api/security/code-scanning/2](https://github.com/unitaryfoundation/metriq-api/security/code-scanning/2)

To fix the issue, we should use parameterized queries to safely embed the `parentId` value into the SQL query. Parameterized queries ensure that the user input is treated as a literal value rather than executable SQL code, thereby preventing SQL injection attacks.

In the `getChildren` method of `metriq-api/service/methodService.js`, replace the string concatenation approach with a parameterized query using Sequelize's query method. This involves passing the `parentId` as a parameter to the query.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
