### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/metriq-api/index.js
+++ b/metriq-api/index.js
@@ -1,8 +1,5 @@
 process.env.METRIQ_MODE = undefined
 
-function sanitizeConnectionString(connectionString) {
-  return connectionString.replace(/:(.*?)@/, ':<REDACTED>@');
-}
 // Get the connection string
 const config = require('./config')
 // Import express

--- a/metriq-api/index.js
+++ b/metriq-api/index.js
@@ -1,4 +1,8 @@
 process.env.METRIQ_MODE = undefined
+
+function sanitizeConnectionString(connectionString) {
+  return connectionString.replace(/:(.*?)@/, ':<REDACTED>@');
+}
 // Get the connection string
 const config = require('./config')
 // Import express
@@ -135,7 +139,7 @@ app.use(unless(publicApiRoutes, async function (req, res, next) {
 }))
 
 // Connect to PostgreSQL
-console.log(config.pgConnectionString)
+console.log(sanitizeConnectionString(config.pgConnectionString))
 const sequelize = new Sequelize(config.pgConnectionString, { logging: false })
 
 // Add a check for DB connection.

--- a/metriq-api/index.js
+++ b/metriq-api/index.js
@@ -139,7 +139,6 @@ app.use(unless(publicApiRoutes, async function (req, res, next) {
 }))
 
 // Connect to PostgreSQL
-console.log(sanitizeConnectionString(config.pgConnectionString))
 const sequelize = new Sequelize(config.pgConnectionString, { logging: false })
 
 // Add a check for DB connection.


### PR DESCRIPTION
Potential fix for [https://github.com/unitaryfoundation/metriq-api/security/code-scanning/1](https://github.com/unitaryfoundation/metriq-api/security/code-scanning/1)

To fix the issue, we need to ensure that sensitive information, such as the database password, is not logged. Instead of logging the full connection string, we can log a sanitized version that excludes sensitive details. This can be achieved by constructing a version of the connection string that omits the password before logging it. 

The fix involves:
1. Modifying the logging statement on line 138 in `metriq-api/index.js` to log a sanitized version of `config.pgConnectionString`.
2. Adding a utility function to sanitize the connection string by removing the password.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
