### PR TITLE
Potential fix for code scanning alert no. 24: Missing rate limiting

### DIFF
--- a/metriq-api/api-routes.js
+++ b/metriq-api/api-routes.js
@@ -39,8 +39,16 @@ router.route('/recover')
   .post(accountController.recover)
 router.route('/password')
   .post(accountController.password)
+const rateLimit = require('express-rate-limit');
+
+const updatePasswordLimiter = rateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: 5, // Limit each IP to 5 requests per windowMs
+  message: 'Too many password update attempts from this IP, please try again after a minute.'
+});
+
 router.route('/user/password')
-  .post(accountController.update_password)
+  .post(updatePasswordLimiter, accountController.update_password)
 router.route('/user')
   .get(userController.read)
   .post(userController.update)

--- a/metriq-api/package.json
+++ b/metriq-api/package.json
@@ -41,7 +41,8 @@
     "sequelize": "^6.6.5",
     "standard": "^16.0.3",
     "twitter-api-v2": "^1.12.5",
-    "uuid": "^8.3.2"
+    "uuid": "^8.3.2",
+    "express-rate-limit": "^7.5.0"
   },
   "jest": {
     "testEnvironment": "node"


### PR DESCRIPTION
Potential fix for [https://github.com/unitaryfoundation/metriq-api/security/code-scanning/24](https://github.com/unitaryfoundation/metriq-api/security/code-scanning/24)

To fix the issue, we will add rate limiting to the `accountController.update_password` route. We will use the `express-rate-limit` package to define a rate limiter and apply it specifically to this route. The rate limiter will restrict the number of requests a client can make to the `update_password` endpoint within a specified time window, mitigating the risk of brute-force or denial-of-service attacks.

Steps:
1. Install the `express-rate-limit` package if it is not already installed.
2. Import the `express-rate-limit` package in the `api-routes.js` file.
3. Define a rate limiter with appropriate settings (e.g., a maximum of 5 requests per minute).
4. Apply the rate limiter to the `router.route('/user/password').post(accountController.update_password)` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
